### PR TITLE
minor fixes and cleanups for the wasm target

### DIFF
--- a/Makefile.fpc
+++ b/Makefile.fpc
@@ -91,6 +91,9 @@ endif
 ifeq ($(CPU_TARGET),riscv64)
 PPSUF=rv64
 endif
+ifeq ($(CPU_TARGET),wasm)
+PPSUF=wasm
+endif
 
 # cross compilers uses full cpu_target, not just ppc-suffix
 # (except if the target cannot run a native compiler)

--- a/compiler/Makefile.fpc
+++ b/compiler/Makefile.fpc
@@ -32,7 +32,7 @@ fpcdir=..
 unexport FPC_VERSION FPC_COMPILERINFO
 
 # Which platforms are ready for inclusion in the cycle
-CYCLETARGETS=i386 powerpc sparc arm x86_64 powerpc64 m68k armeb mipsel mips avr jvm i8086 aarch64 sparc64 riscv32 riscv64
+CYCLETARGETS=i386 powerpc sparc arm x86_64 powerpc64 m68k armeb mipsel mips avr jvm i8086 aarch64 sparc64 riscv32 riscv64 wasm
 
 # All supported targets used for clean
 ALLTARGETS=$(CYCLETARGETS)
@@ -225,6 +225,9 @@ endif
 ifeq ($(CPC_TARGET),riscv64)
 CPUSUF=rv64
 endif
+ifeq ($(CPC_TARGET),wasm)
+CPUSUF=wasm
+endif
 
 # Do not define the default -d$(CPU_TARGET) because that
 # will conflict with our -d$(CPC_TARGET)
@@ -354,6 +357,11 @@ endif
 # RiscV64 specific
 ifeq ($(PPC_TARGET),riscv64)
 override LOCALOPT+=-Furiscv
+endif
+
+# WASM specific
+ifeq ($(PPC_TARGET),wasm)
+override LOCALOPT+=-dNOOPT
 endif
 
 OPTWPOCOLLECT=-OWdevirtcalls,optvmts -FW$(BASEDIR)/pp1.wpo
@@ -586,8 +594,8 @@ endif
 # cpu targets
 #####################################################################
 
-PPC_TARGETS=i386 m68k powerpc sparc arm armeb x86_64 powerpc64 mips mipsel avr jvm i8086 aarch64 sparc64 riscv32 riscv64
-PPC_SUFFIXES=386 68k ppc sparc arm armeb x64 ppc64 mips mipsel avr jvm 8086 a64 sparc64 rv32 rv64
+PPC_TARGETS=i386 m68k powerpc sparc arm armeb x86_64 powerpc64 mips mipsel avr jvm i8086 aarch64 sparc64 riscv32 riscv64 wasm
+PPC_SUFFIXES=386 68k ppc sparc arm armeb x64 ppc64 mips mipsel avr jvm 8086 a64 sparc64 rv32 rv64 wasm
 INSTALL_TARGETS=$(addsuffix _exe_install,$(sort $(CYCLETARGETS) $(PPC_TARGETS)))
 SYMLINKINSTALL_TARGETS=$(addsuffix _symlink_install,$(sort $(CYCLETARGETS) $(PPC_TARGETS)))
 

--- a/compiler/options.pas
+++ b/compiler/options.pas
@@ -3705,6 +3705,13 @@ procedure read_arguments(cmd:TCmdStr);
         def_system_macro('FPC_REQUIRES_PROPER_ALIGNMENT');
       {$endif riscv64}
 
+      {$ifdef wasm}
+        def_system_macro('CPUWASM');
+        def_system_macro('CPU32');
+        def_system_macro('FPC_CURRENCY_IS_INT64');
+        def_system_macro('FPC_COMP_IS_INT64');
+      {$endif wasm}
+
       {$if defined(cpu8bitalu)}
         def_system_macro('CPUINT8');
       {$elseif defined(cpu16bitalu)}

--- a/compiler/systems.pas
+++ b/compiler/systems.pas
@@ -198,14 +198,14 @@ interface
           resobjext    : string[7];
           sharedlibext : string[10];
           staticlibext,
-          staticlibprefix : string[4];
+          staticlibprefix : string[6];
           sharedlibprefix : string[4];
           sharedClibext : string[10];
           staticClibext,
-          staticClibprefix : string[4];
+          staticClibprefix : string[6];
           sharedClibprefix : string[4];
           importlibprefix : string[10];
-          importlibext : string[4];
+          importlibext : string[6];
           Cprefix      : string[2];
           newline      : string[2];
           dirsep       : char;

--- a/compiler/systems/t_wasm.pas
+++ b/compiler/systems/t_wasm.pas
@@ -1,5 +1,7 @@
 unit t_wasm;
 
+{$i fpcdefs.inc}
+
 interface
 
 uses

--- a/compiler/utils/mkwasmreg.pp
+++ b/compiler/utils/mkwasmreg.pp
@@ -12,7 +12,7 @@
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
  **********************************************************************}
-program mkspreg;
+program mkwasmreg;
 
 const Version = '1.00';
       max_regcount = 200;

--- a/compiler/wasm/agbinaryen.pas
+++ b/compiler/wasm/agbinaryen.pas
@@ -55,7 +55,6 @@ interface
         function CreateNewAsmWriter: TExternalAssemblerOutputFile; override;
        public
         constructor CreateWithWriter(info: pasminfo; wr: TExternalAssemblerOutputFile; freewriter, smart: boolean); override;
-        function MakeCmdLine: TCmdStr;override;
         procedure WriteTree(p:TAsmList);override;
         procedure WriteAsmList;override;
         destructor destroy; override;
@@ -469,14 +468,6 @@ implementation
       begin
         InstrWriter.WriteInstruction(hp);
       end;
-
-
-   function TBinaryenAssembler.MakeCmdLine: TCmdStr;
-     begin
-       Replace(result,'$EXTRAOPT',asmextraopt);
-     end;
-
-
 
 
     function TBinaryenAssembler.CreateNewAsmWriter: TExternalAssemblerOutputFile;

--- a/compiler/wasm/agwat.pas
+++ b/compiler/wasm/agwat.pas
@@ -23,6 +23,9 @@
 }
 unit agwat;
 
+
+{$i fpcdefs.inc}
+
 interface
 
   uses

--- a/compiler/wasm/nwasmflw.pas
+++ b/compiler/wasm/nwasmflw.pas
@@ -21,6 +21,8 @@
 }
 unit nwasmflw;
 
+{$i fpcdefs.inc}
+
 interface
 
 uses

--- a/compiler/wasm/wasmdef.pas
+++ b/compiler/wasm/wasmdef.pas
@@ -1,5 +1,7 @@
 unit wasmdef;
 
+{$i fpcdefs.inc}
+
 interface
 
 uses


### PR DESCRIPTION
Minor fixes and cleanups for the `wasm` target, which should help eventual SVN trunk integration, and build inside the FPC build system. (Needs regenerated `Makefiles` after merge.)